### PR TITLE
Removed hierarchy's custom drophandler and replaced with default.

### DIFF
--- a/VSProjects/Geomapmaker/Views/Hierarchy/Hierarchy.xaml
+++ b/VSProjects/Geomapmaker/Views/Hierarchy/Hierarchy.xaml
@@ -8,7 +8,7 @@
         xmlns:extensions="clr-namespace:ArcGIS.Desktop.Extensions;assembly=ArcGIS.Desktop.Extensions"
         xmlns:models="clr-namespace:Geomapmaker.Models"
         xmlns:dd="urn:gong-wpf-dragdrop"
-        xmlns:viewmodels="clr-namespace:Geomapmaker.ViewModels"
+        xmlns:viewmodels="clr-namespace:Geomapmaker.ViewModels.Hierarchy"
         d:DataContext="{d:DesignInstance Type=viewmodels:HierarchyViewModel}"
         mc:Ignorable="d"
         Title="Hierarchy"
@@ -30,7 +30,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="5" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
+            <RowDefinition Height="3*" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
@@ -46,7 +46,7 @@
         </Grid.ColumnDefinitions>
 
         <TextBlock Grid.Row="1" Grid.Column="1" Text="Hierarchy Tree" />
-        <TreeView Name="Tree" Grid.Row="2" Grid.Column="1" ItemsSource="{Binding Tree}" dd:DragDrop.IsDragSource="True" dd:DragDrop.IsDropTarget="True" dd:DragDrop.DropHandler="{Binding}" MinHeight="25">
+        <TreeView Name="Tree" Grid.Row="2" Grid.Column="1" ItemsSource="{Binding Tree}" dd:DragDrop.IsDragSource="True" dd:DragDrop.IsDropTarget="True" >
             <TreeView.ItemContainerStyle>
                 <Style TargetType="{x:Type TreeViewItem}">
                     <Setter Property="IsExpanded" Value="True" />
@@ -88,7 +88,7 @@
         </TreeView>
 
         <TextBlock Grid.Row="3" Grid.Column="1" Text="Unassigned" />
-        <ListBox Name="Unassigned" Grid.Row="4" Grid.Column="1" ItemsSource="{Binding Unassigned}" dd:DragDrop.IsDragSource="True" dd:DragDrop.IsDropTarget="True" dd:DragDrop.DropHandler="{Binding}">
+        <ListBox Name="Unassigned" Grid.Row="4" Grid.Column="1" ItemsSource="{Binding Unassigned}" dd:DragDrop.IsDragSource="True" dd:DragDrop.IsDropTarget="False" >
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
The custom handler didn't have great support for positional changes for nodes within a hierarchy level. Using the default handler and preventing dragging nodes from the tree back to the unassigned list. 