### PR TITLE
Prevent OP layer from generating default templates.

### DIFF
--- a/VSProjects/Geomapmaker/Data/OrientationPoints.cs
+++ b/VSProjects/Geomapmaker/Data/OrientationPoints.cs
@@ -189,6 +189,11 @@ namespace Geomapmaker.Data
                 {
                     if (opTable != null)
                     {
+                        // Prevent default templates from generating 
+                        CIMBasicFeatureLayer layerDef = opLayer.GetDefinition() as CIMBasicFeatureLayer;
+                        layerDef.AutoGenerateFeatureTemplates = false;
+                        opLayer.SetDefinition(layerDef);
+
                         // Remove all existing symbols
                         opLayer.SetRenderer(opLayer.CreateRenderer(new SimpleRendererDefinition()));
 


### PR DESCRIPTION
 Features should only be added using the form.