### PR TITLE
MUP select box fix

### DIFF
--- a/VSProjects/Geomapmaker/Data/MapUnitPolys.cs
+++ b/VSProjects/Geomapmaker/Data/MapUnitPolys.cs
@@ -395,7 +395,7 @@ namespace Geomapmaker.Data
                     List<string> defaultValuesKeys = templateDef?.DefaultValues?.Keys?.ToList();
 
                     // If the template has values (Unassigned template does not)
-                    if (defaultValuesKeys != null && defaultValuesKeys?.Count == 2)
+                    if (defaultValuesKeys != null && defaultValuesKeys?.Count >= 2)
                     {
                         if (defaultValuesKeys[0].ToLower() == "mapunit" && defaultValuesKeys[1].ToLower() == "datasourceid")
                         {


### PR DESCRIPTION
Check if the template has 2 or more default values instead of exactly 2. SQL Server saves default template values for Shape.STArea() and Shape.STLength()